### PR TITLE
Compatibility with newer Scrapy versions

### DIFF
--- a/history/storage.py
+++ b/history/storage.py
@@ -5,7 +5,7 @@ import pickle
 from scrapy import log
 from scrapy.conf import settings
 from scrapy.utils.request import request_fingerprint
-from scrapy.core.downloader.responsetypes import responsetypes
+from scrapy.responsetypes import responsetypes
 
 
 class S3CacheStorage(object):


### PR DESCRIPTION
Closes playandbuild/scrapy-history-middleware#2.

I haven't tested this in-tree, not sure how the test script works (I've cherry-picked the changes from my own copy having other changes as well).

[On another note, parsedatetime needs a version higher than the one in Ubuntu right now (1.4). If you know the exact version, it may be nice to specify in requirements.txt]
