### PR TITLE
Hotfix/robust metadata truncating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 
 .coverage
 htmlcov/
+.idea

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ The primary authors and contributors are:
 
   * Andrew Preston (preston.co.nz, github.com/arhpreston)
   * Joel Pitt (github.com/ferrouswheel)
+  * Jean Maynier (fork)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node {
     stage 'Checkout'
         checkout scm
 
-    stage 'Build' {}
+    stage 'Build'
         echo "Building ${BRANCH_NAME}"
         sh 'chmod +x runtests.sh'
         sh './runtests.sh'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,10 @@
+node {
+    // Checkout code from repository
+    stage 'Checkout'
+        checkout scm
+
+    stage 'Build' {}
+        echo "Building ${BRANCH_NAME}"
+        sh 'chmod +x runtests.sh'
+        sh './runtests.sh'
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,32 @@
 node {
-    // Checkout code from repository
-    stage 'Checkout'
-        checkout scm
+    try {
+        notifyStarted()
+        
+        // Checkout code from repository
+        stage 'Checkout'
+            checkout scm
 
-    stage 'Build'
-        echo "Building ${BRANCH_NAME}"
-        sh 'chmod +x runtests.sh'
-        sh './runtests.sh'
+        stage 'Build'
+            echo "Building ${BRANCH_NAME}"
+            sh 'chmod +x runtests.sh'
+            sh './runtests.sh'
+        
+        notifySuccessful()
+    } catch(e) {
+        currentBuild.result = "FAILED"
+        notifyFailed()
+        throw e
+    }
+}
+
+def notifyStarted() {
+    slackSend (color: '#FFFF00', message: "STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+}
+
+def notifySuccessful() {
+    slackSend (color: '#00FF00', message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+}
+
+def notifyFailed() {
+    slackSend (color: '#FF0000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
 }

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ example:
     HISTORY_STORE_IF = 'history.logic.StoreAlways'
     HISTORY_RETRIEVE_IF = 'history.logic.RetrieveAlways'
     HISTORY_BACKEND = 'history.storage.S3CacheStorage'
-    HISTORY_SAVE_SOURCE = '{name}/{ts}__{jobid}'
-    HISTORY_S3_BUCKET = 'YOUR_S3_BUCKET'
+    HISTORY_SAVE_SOURCE = '{name}/{time}__{jobid}'
+    HISTORY_S3_BUCKET = 'YOUR_S3_CACHE_BUCKET_NAME'
     HISTORY_USE_PROXY = True
     HTTPCACHE_IGNORE_MISSING = False
 ```
@@ -125,10 +125,10 @@ You also have to add the settings in the `spider settings` section of the webpag
     HISTORY_STORE_IF= 'history.logic.StoreAlways'
     HISTORY_RETRIEVE_IF = 'history.logic.RetrieveAlways'
     HISTORY_BACKEND = 'history.storage.S3CacheStorage'
-    HISTORY_SAVE_SOURCE = '{name}/{ts}__{jobid}'
-    HISTORY_S3_ACCESS_KEY = {{ AWS_ACCESS_KEY_ID }}
-    HISTORY_S3_SECRET_KEY = {{ AWS_SECRET_ACCESS_KEY }}
-    HISTORY_S3_BUCKET = {{ S3_BUCKET }}
-    HISTORY_USE_PROXY = True 
+    HISTORY_SAVE_SOURCE = '{name}/{time}__{jobid}'
+    HISTORY_S3_ACCESS_KEY = 'YOUR_AWS_ACCESS_KEY_ID'
+    HISTORY_S3_SECRET_KEY = 'YOUR_AWS_SECRET_ACCESS_KEY'
+    HISTORY_S3_BUCKET = 'YOUR_S3_CACHE_BUCKET_NAME'
+    HISTORY_USE_PROXY = True
     HTTPCACHE_IGNORE_MISSING = False
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 scrapy-history-middleware
 =========================
 
+[![CircleCI](https://circleci.com/gh/Kpler/scrapy-history-middleware.svg?style=svg)](https://circleci.com/gh/Kpler/scrapy-history-middleware)
+
 The history middleware is designed to create a permanent record of the
 raw requests and responses generated as scrapy crawls the web.
 
@@ -14,17 +16,16 @@ example:
     DOWNLOADER_MIDDLEWARES = {
         'history.middleware.HistoryMiddleware': 901 # Right after HttpCacheMiddleware
     }
-
-    EPOCH = True
-    HISTORY = {
-        'STORE_IF'   : 'history.logic.StoreAlways',
-        'RETRIEVE_IF': 'history.logic.RetrieveAlways',
-        'BACKEND'    : 'history.storage.S3CacheStorage',
-        'S3_ACCESS_KEY': {{ AWS_ACCESS_KEY_ID }},
-        'S3_SECRET_KEY': {{ AWS_SECRET_ACCESS_KEY }},
-        'S3_BUCKET'    : {{ S3_BUCKET }},
-        'USE_PROXY'  : True,
-    }
+    AWS_ACCESS_KEY_ID = 'YOUR_AWS_ACCESS_KEY_ID'
+    AWS_SECRET_ACCESS_KEY = 'YOUR_AWS_SECRET_ACCESS_KEY'
+    HISTORY_EPOCH = True
+    HISTORY_STORE_IF = 'history.logic.StoreAlways'
+    HISTORY_RETRIEVE_IF = 'history.logic.RetrieveAlways'
+    HISTORY_BACKEND = 'history.storage.S3CacheStorage'
+    HISTORY_SAVE_SOURCE = '{name}/{ts}__{jobid}'
+    HISTORY_S3_BUCKET = 'YOUR_S3_BUCKET'
+    HISTORY_USE_PROXY = True
+    HTTPCACHE_IGNORE_MISSING = False
 ```
 
 Will store and retrieve responses exactly as you expect. However, even
@@ -57,55 +58,77 @@ middleware. As such, the default logic modules use
 `HTTPCACHE_IGNORE_HTTP_CODES`, and responses will not be stored if
 they are flagged as having returned from the cache storage.
 
-The middleware also requires two other settings: `EPOCH` and
-`HISTORY`.
-
 ### Epoch
 
-Usage: EPOCH can either be defined in `settings.py`,
-`local_settings.py`, or on the command line, eg.,:
+# Settings:
 
-```bash
-    $ scrapy crawl {{ spider }} --set="EPOCH=yesterday"
-```
+  * `HISTORY_USE_PROXY`:
+    Usage: HISTORY_EPOCH can either be defined in `settings.py`,
+    `local_settings.py`, or on the command line, eg.,:
+  
+    ```bash
+  	$ scrapy crawl {{ spider }} --set="HISTORY_EPOCH=yesterday"
+    ```
+    
+    Note that scrapy will choose the value in local_settings.py over the
+    command line.
 
-Note that scrapy will choose the value in local_settings.py over the
-command line.
+    Possible values:
+  
+      * `True`: The middleware will always try to retrieve the most
+        recently stored version of a url, subject to the logic in
+        `RETRIEVE_IF`.
 
-Possible values:
+      * `False` (default): The middleware won't ever try to retrieve
+        stored responses.
 
-  * `True`: The middleware will always try to retrieve the most
-    recently stored version of a url, subject to the logic in
-    `RETRIEVE_IF`.
+      * `{{ string }}`: The middleware will attempt to generate a datetime
+        using the heuristics of the
+        [parsedatetime](http://code.google.com/p/parsedatetime/)
+        module. The retrieved response will either be newer than `EPOCH`,
+        or the most recently stored response.
 
-  * `False` (default): The middleware won't ever try to retrieve
-    stored responses.
-
-  * `{{ string }}`: The middleware will attempt to generate a datetime
-    using the heuristics of the
-    [parsedatetime](http://code.google.com/p/parsedatetime/)
-    module. The retrieved response will either be newer than `EPOCH`,
-    or the most recently stored response.
-
-### History
-
-A dictionary containing:
-
-  * `STORE_IF`: (default `history.logic.StoreAlways`) Path to a
+  * `HISTORY_STORE_IF`: (default `history.logic.StoreAlways`) Path to a
     callable that accepts the current spider, request, and response as
     arguments and returns `True` if the response should be stored, or
     `False` otherwise.
 
-  * `RETRIEVE_IF`: (default `history.logic.RetrieveNever`) Path to a
+  * `HISTORY_RETRIEVE_IF`: (default `history.logic.RetrieveNever`) Path to a
     callable that accepts the current spider and request as arguments
     and returns `True` if the response should be retrieved from the
     storage backend, or `False` otherwise.
 
-  * `BACKEND`: (default `history.storage.S3CacheStorage`) The storage
+  * `HISTORY_BACKEND`: (default `history.storage.S3CacheStorage`) The storage
     backend.
 
   * `S3_ACCESS_KEY`: Required if using `S3CacheStorage`.
 
   * `S3_BUCKET_KEY`: Required if using `S3CacheStorage`.
 
-  * `S3_BUCKET`: Required if using `S3CacheStorage`.
+  * `HISTORY_S3_BUCKET`: Required if using `S3CacheStorage`.
+
+  * `HISTORY_USE_PROXY`: Mention if boto should be using a proxy to connect to the S3 bucket
+
+## Using it with Scrapinghub
+
+In order to activate this middleware on Scrapinghub, you need to add it on your pypi and mention it in the requirements.txt file of your scrapy project.
+
+You also have to add the settings in the `spider settings` section of the webpage if you want to activate it for all spiders. Else, add these settings to the settings section of the specific spider for which you want to use the middleware.
+
+```python
+
+    DOWNLOADER_MIDDLEWARES = {
+        'history.middleware.HistoryMiddleware': 901 # Right after HttpCacheMiddleware
+    }
+
+    HISTORY_EPOCH = True
+    HISTORY_STORE_IF= 'history.logic.StoreAlways'
+    HISTORY_RETRIEVE_IF = 'history.logic.RetrieveAlways'
+    HISTORY_BACKEND = 'history.storage.S3CacheStorage'
+    HISTORY_SAVE_SOURCE = '{name}/{ts}__{jobid}'
+    HISTORY_S3_ACCESS_KEY = {{ AWS_ACCESS_KEY_ID }}
+    HISTORY_S3_SECRET_KEY = {{ AWS_SECRET_ACCESS_KEY }}
+    HISTORY_S3_BUCKET = {{ S3_BUCKET }}
+    HISTORY_USE_PROXY = True 
+    HTTPCACHE_IGNORE_MISSING = False
+```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,5 @@
+nose
+nose-cov
+coverage
+
+-r requirements.txt

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -2,7 +2,7 @@
 """
 
 __title__ = 'history'
-__version__ = '0.9.6'
+__version__ = '0.9.9'
 
 
 #from history.middleware import HistoryMiddleware

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -2,7 +2,7 @@
 """
 
 __title__ = 'history'
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 
 
 #from history.middleware import HistoryMiddleware

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -2,7 +2,7 @@
 """
 
 __title__ = 'history'
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 
 
 #from history.middleware import HistoryMiddleware

--- a/history/__init__.py
+++ b/history/__init__.py
@@ -2,7 +2,7 @@
 """
 
 __title__ = 'history'
-__version__ = '0.9.3'
+__version__ = '0.9.6'
 
 
 #from history.middleware import HistoryMiddleware

--- a/history/logic.py
+++ b/history/logic.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from scrapy.conf import settings
 from scrapy.utils.httpobj import urlparse_cached
@@ -41,6 +41,7 @@ class LogicBase(object):
 
         return cacheable_request and cacheable_response
 
+
 class RetrieveBase(LogicBase):
     def __call__(self, spider, request, response=None):
         if self._cache_if(spider, request):
@@ -50,6 +51,7 @@ class RetrieveBase(LogicBase):
 
     def retrieve_if(self, spider, request):
         raise NotImplementedError("Please implement in your subclass.")
+
 
 class StoreBase(LogicBase):
     def __call__(self, spider, request, response):
@@ -69,6 +71,7 @@ class RetrieveNever(RetrieveBase):
     def retrieve_if(self, spider, request):
         return False
 
+
 class RetrieveAlways(RetrieveBase):
     """
     Always attempt to retrieve response from.
@@ -84,12 +87,14 @@ class StoreNever(StoreBase):
     def store_if(self, spider, request, response):
         return False
 
+
 class StoreAlways(StoreBase):
     """
     Always attempt to store response in cache.
     """
     def store_if(self, spider, request, response):
         return True
+
 
 class StoreDaily(StoreBase):
     """

--- a/history/middleware.py
+++ b/history/middleware.py
@@ -22,14 +22,14 @@ class HistoryMiddleware(object):
         #   == False: don't retrieve historical data
         #   == True : retrieve most recent version
         #   == datetime(): retrieve next version after datetime()
-        self.epoch = self.parse_epoch(settings.get('EPOCH', False))
+        self.epoch = self.parse_epoch(settings.get('HISTORY_EPOCH', False))
 
-        self.retrieve_if = load_object(history.get(
-            'RETRIEVE_IF', 'history.logic.RetrieveNever'))(settings)
-        self.store_if = load_object(history.get(
-            'STORE_IF', 'history.logic.StoreAlways'))(settings)
-        self.storage = load_object(history.get(
-            'BACKEND', 'history.storage.S3CacheStorage'))(self.stats, settings)
+        self.retrieve_if = load_object(settings.get(
+            'HISTORY_RETRIEVE_IF', 'history.logic.RetrieveNever'))(settings)
+        self.store_if = load_object(settings.get(
+            'HISTORY_STORE_IF', 'history.logic.StoreAlways'))(settings)
+        self.storage = load_object(settings.get(
+            'HISTORY_BACKEND', 'history.storage.S3CacheStorage'))(self.stats, settings)
         self.ignore_missing = settings.getbool('HTTPCACHE_IGNORE_MISSING')
 
         dispatcher.connect(self.spider_opened, signal=signals.spider_opened)

--- a/history/middleware.py
+++ b/history/middleware.py
@@ -29,7 +29,7 @@ class HistoryMiddleware(object):
         self.store_if = load_object(history.get(
             'STORE_IF', 'history.logic.StoreAlways'))(settings)
         self.storage = load_object(history.get(
-            'BACKEND', 'history.storage.S3CacheStorage'))(settings)
+            'BACKEND', 'history.storage.S3CacheStorage'))(self.stats, settings)
         self.ignore_missing = settings.getbool('HTTPCACHE_IGNORE_MISSING')
 
         dispatcher.connect(self.spider_opened, signal=signals.spider_opened)

--- a/history/storage.py
+++ b/history/storage.py
@@ -176,7 +176,9 @@ class S3CacheStorage(object):
             #save source file
             if self.SAVE_SOURCE:
                 job_folder = self.SAVE_SOURCE % self._get_uri_params(spider)
-                source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request), urllib.quote_plus(request.url))
+                source_url = request.url[:400] + '...' if len(request.url) > 400 else request.url
+
+                source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request), urllib.quote_plus(source_url))
                 source_key = self.s3_bucket.new_key(source_name)
                 source_key.set_contents_from_string(response.body)
         except boto.exception.S3ResponseError as e:

--- a/history/storage.py
+++ b/history/storage.py
@@ -176,7 +176,8 @@ class S3CacheStorage(object):
             #save source file
             if self.SAVE_SOURCE:
                 job_folder = self.SAVE_SOURCE % self._get_uri_params(spider)
-                source_url = request.url[:400] + '...' if len(request.url) > 400 else request.url
+                # if the S3 key is too long, the AWS interface does not allow to download the file !
+                source_url = request.url[:200] + '...' if len(request.url) > 200 else request.url
 
                 source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request), urllib.quote_plus(source_url))
                 source_key = self.s3_bucket.new_key(source_name)

--- a/history/storage.py
+++ b/history/storage.py
@@ -12,15 +12,14 @@ from scrapy.responsetypes import responsetypes
 class S3CacheStorage(object):
 
     def __init__(self, stats, settings=settings):
-        history = settings.get('HISTORY')
         # Required settings
-        self.S3_ACCESS_KEY   = history['S3_ACCESS_KEY']
-        self.S3_SECRET_KEY   = history['S3_SECRET_KEY']
-        self.S3_CACHE_BUCKET = history['S3_BUCKET']
+        self.S3_ACCESS_KEY   = settings.get('AWS_ACCESS_KEY_ID')
+        self.S3_SECRET_KEY   = settings.get('AWS_SECRET_ACCESS_KEY')
+        self.S3_CACHE_BUCKET = settings.get('HISTORY_S3_BUCKET')
 
         # Optional settings
-        self.use_proxy = history.get('USE_PROXY', True)
-        self.SAVE_SOURCE = history['SAVE_SOURCE']
+        self.use_proxy = settings.get('HISTORY_USE_PROXY', True)
+        self.SAVE_SOURCE = settings.get('HISTORY_SAVE_SOURCE')
         self.stats = stats
 
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -142,7 +142,7 @@ class S3CacheStorage(object):
             'response_headers': response.headers,
             'response_body'   : response.body
         }
-        data_string = json.dumps(data)
+        data_string = json.dumps(data, ensure_ascii=False, encoding='utf-8')
 
         # With versioning enabled creating a new s3_key is not
         # necessary. We could just write over an old s3_key. However,

--- a/history/storage.py
+++ b/history/storage.py
@@ -133,6 +133,7 @@ class S3CacheStorage(object):
         key = self._get_key(spider, request)
 
         logger.info('S3Storage: path %s' % key)
+        logger.debug('S3Storage: encoding {} '.format(response.encoding))
         metadata = {
             'url': request.url,
             'method': request.method,

--- a/history/storage.py
+++ b/history/storage.py
@@ -194,6 +194,7 @@ class S3CacheStorage(object):
             #    log.msg('S3Storage: %s %s - %s' % (e.status, e.reason, e.body), log.ERROR)
             raise e
         finally:
+            source_key.close()
             s3_key.close()
 
     #from https://github.com/scrapy/scrapy/blob/342cb622f1ea93268477da557099010bbd72529a/scrapy/extensions/feedexport.py

--- a/history/storage.py
+++ b/history/storage.py
@@ -11,7 +11,7 @@ from scrapy import log
 from scrapy.conf import settings
 from scrapy.utils.request import request_fingerprint
 from scrapy.responsetypes import responsetypes
-from scrapy.http import TextResponse
+from scrapy.http import TextResponse, Headers
 
 
 logger = logging.getLogger(__name__)
@@ -117,9 +117,9 @@ class S3CacheStorage(object):
         data = json.loads(data_string)
 
         metadata         = data['metadata']
-        request_headers  = data['request_headers']
+        request_headers  = Headers(data['request_headers'])
         request_body     = data['request_body']
-        response_headers = data['response_headers']
+        response_headers = Headers(data['response_headers'])
         response_body    = data['response_body']
 
         if 'binary' in data and data['binary'] == True:
@@ -127,6 +127,8 @@ class S3CacheStorage(object):
 
         url      = metadata['response_url']
         status   = metadata.get('status')
+
+        # bug in scrapy 1.0
         Response = responsetypes.from_args(headers=response_headers, url=url, body=response_body)
         return Response(url=url, headers=response_headers, status=status, body=response_body)
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -123,13 +123,16 @@ class S3CacheStorage(object):
         response_body    = data['response_body']
 
         if 'binary' in data and data['binary'] == True:
+            logger.debug('S3Storage: retrieved binary body')
             response_body = base64.decode(response_body)
 
         url      = metadata['response_url']
         status   = metadata.get('status')
 
-        # bug in scrapy 1.0
+        logger.debug('S3Storage: response headers {} '.format(response_headers))
         Response = responsetypes.from_args(headers=response_headers, url=url, body=response_body)
+        logger.debug('S3Storage: response type {} '.format(Response))
+
         return Response(url=url, headers=response_headers, status=status, body=response_body)
 
     def store_response(self, spider, request, response):
@@ -150,8 +153,7 @@ class S3CacheStorage(object):
             # Binary response (excel, pdf, etc.)
             binary = True
             response_body = base64.b64encode(response.body)
-            logger.debug('S3Storage: body type {} '.format(type(response._body)))
-            logger.debug('S3Storage: responsetypes {}'.format(responsetypes.from_args(headers=response.headers, url=response.url, body=response.body)))
+            logger.debug('S3Storage: body type {} '.format(type(response_body)))
         logger.debug('S3Storage: request header {}'.format(request.headers))
         logger.debug('S3Storage: response header {}'.format(response.headers))
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -20,15 +20,15 @@ class S3CacheStorage(object):
 
     def __init__(self, stats, settings=settings):
         # Required settings
-        self.S3_ACCESS_KEY   = settings.get('AWS_ACCESS_KEY_ID')
-        self.S3_SECRET_KEY   = settings.get('AWS_SECRET_ACCESS_KEY')
-        self.S3_CACHE_BUCKET = settings.get('HISTORY_S3_BUCKET')
+        self.S3_ACCESS_KEY = settings.get('AWS_ACCESS_KEY_ID')
+        self.S3_SECRET_KEY = settings.get('AWS_SECRET_ACCESS_KEY')
+        self.S3_CACHE_BUCKET = settings.get('HISTORY_S3_BUCKET', None)
 
         # Optional settings
-        self.use_proxy = settings.getbool('HISTORY_USE_PROXY', True)
-        self.SAVE_SOURCE = settings.get('HISTORY_SAVE_SOURCE')
+        self.use_proxy = settings.get('HISTORY_USE_PROXY', True)
+        self.SAVE_SOURCE = settings.get('HISTORY_SAVE_SOURCE',
+                                        '{name}/{ts}__{jobid}')
         self.stats = stats
-
 
     def _get_key(self, spider, request):
         key = request_fingerprint(request)
@@ -196,7 +196,7 @@ class S3CacheStorage(object):
 
             #save source file
             if self.SAVE_SOURCE:
-                job_folder = self.SAVE_SOURCE % self._get_uri_params(spider)
+                job_folder = self.SAVE_SOURCE.format(**self._get_uri_params(spider))
                 # if the S3 key is too long, the AWS interface does not allow to download the file !
                 source_url = request.url[:200] + '...' if len(request.url) > 200 else request.url
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -18,7 +18,7 @@ class S3CacheStorage(object):
         self.S3_CACHE_BUCKET = settings.get('HISTORY_S3_BUCKET')
 
         # Optional settings
-        self.use_proxy = settings.get('HISTORY_USE_PROXY', True)
+        self.use_proxy = settings.getbool('HISTORY_USE_PROXY', True)
         self.SAVE_SOURCE = settings.get('HISTORY_SAVE_SOURCE')
         self.stats = stats
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -30,6 +30,10 @@ class S3CacheStorage(object):
     def open_spider(self, spider):
         self.s3_connection = boto.connect_s3(self.S3_ACCESS_KEY, self.S3_SECRET_KEY, is_secure=False)
         self.s3_connection.use_proxy = self.use_proxy
+        #use spider fields to replace var in bucket string
+        if self.S3_CACHE_BUCKET:
+            self.S3_CACHE_BUCKET = self.S3_CACHE_BUCKET % self._get_uri_params(spider)
+
         self.s3_bucket = self.s3_connection.get_bucket(self.S3_CACHE_BUCKET, validate=False)
         #self.versioning = self.s3_bucket.get_versioning_status() #=> {} or {'Versioning': 'Enabled'}
 

--- a/history/storage.py
+++ b/history/storage.py
@@ -159,6 +159,9 @@ class S3CacheStorage(object):
         }
         data_string = json.dumps(data, ensure_ascii=False, encoding='utf-8')
 
+        # sometimes can cause memory error in SH if too big
+        logger.debug('S3Storage: request/response json object size  {}kB'.format(len(data_string) / 1024))
+
         # With versioning enabled creating a new s3_key is not
         # necessary. We could just write over an old s3_key. However,
         # the cost to GET the old s3_key is higher than the cost to
@@ -182,6 +185,8 @@ class S3CacheStorage(object):
                 source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request), urllib.quote_plus(source_url))
                 source_key = self.s3_bucket.new_key(source_name)
                 source_key.set_contents_from_string(response.body)
+                # sometimes can cause memory error in SH if too big
+                logger.debug('S3Storage: body size  {}kB'.format(len(response.body) / 1024))
         except boto.exception.S3ResponseError as e:
             # http://docs.pythonboto.org/en/latest/ref/boto.html#module-boto.exception
             #   S3CopyError        : Error copying a key on S3.

--- a/history/storage.py
+++ b/history/storage.py
@@ -1,33 +1,45 @@
 from __future__ import unicode_literals
 
-from datetime import datetime
-import logging
 import boto
 import base64
+from datetime import datetime
 import json
+import logging
 import urllib
 
-from scrapy import log
 from scrapy.conf import settings
-from scrapy.utils.request import request_fingerprint
-from scrapy.responsetypes import responsetypes
+from scrapy.exceptions import NotConfigured
 from scrapy.http import TextResponse, Headers
+from scrapy.responsetypes import responsetypes
+from scrapy.utils.request import request_fingerprint
+
+MANDATORY_SETTINGS = ['HISTORY_S3_BUCKET',
+                      'AWS_ACCESS_KEY_ID',
+                      'AWS_SECRET_ACCESS_KEY']
 
 
 logger = logging.getLogger(__name__)
 
+
 class S3CacheStorage(object):
 
     def __init__(self, stats, settings=settings):
-        # Required settings
+        # Mandatory settings
         self.S3_ACCESS_KEY = settings.get('AWS_ACCESS_KEY_ID')
         self.S3_SECRET_KEY = settings.get('AWS_SECRET_ACCESS_KEY')
         self.S3_CACHE_BUCKET = settings.get('HISTORY_S3_BUCKET', None)
+        configured = all([settings.get(k, False) for k in MANDATORY_SETTINGS])
+        if not configured:
+            raise NotConfigured('% are mandatoy settings, set them either from the settings file '
+                                'or from the Scrapinghub spider settings '
+                                'section.' % ','.join(MANDATORY_SETTINGS))
 
         # Optional settings
-        self.use_proxy = settings.get('HISTORY_USE_PROXY', True)
+        # boto s3_connection does not work through proxy.
+        # comment this line from the original file
+        # self.use_proxy = settings.get('HISTORY_USE_PROXY', False)
         self.SAVE_SOURCE = settings.get('HISTORY_SAVE_SOURCE',
-                                        '{name}/{ts}__{jobid}')
+                                        '{name}/{time}__no_job_id')
         self.stats = stats
 
     def _get_key(self, spider, request):
@@ -35,14 +47,23 @@ class S3CacheStorage(object):
         return '%s/cache/%s' % (spider.name, key)
 
     def open_spider(self, spider):
-        self.s3_connection = boto.connect_s3(self.S3_ACCESS_KEY, self.S3_SECRET_KEY, is_secure=False)
-        self.s3_connection.use_proxy = self.use_proxy
-        #use spider fields to replace var in bucket string
-        if self.S3_CACHE_BUCKET:
-            self.S3_CACHE_BUCKET = self.S3_CACHE_BUCKET % self._get_uri_params(spider)
-
-        self.s3_bucket = self.s3_connection.get_bucket(self.S3_CACHE_BUCKET, validate=False)
-        #self.versioning = self.s3_bucket.get_versioning_status() #=> {} or {'Versioning': 'Enabled'}
+        self.s3_connection = boto.connect_s3(self.S3_ACCESS_KEY,
+                                             self.S3_SECRET_KEY,
+                                             # Fails with understandable Traceback
+                                             # if is_secure is set to True.
+                                             # Else it will fail on S3Connection.get_bucket()
+                                             # with a super vague message Trace:
+                                             # TypeError: int() argument must be a string
+                                             #   or a number, not 'NoneType'
+                                             is_secure=True)
+        # S3Connection does not work when using proxy. S3Connection.use_proxy must be set to False.
+        self.s3_connection.use_proxy = False
+        # Use spider fields to replace var in key name.
+        self.SAVE_SOURCE = self.SAVE_SOURCE.format(**self._get_uri_params(spider))
+        # The bucket keeps the name given 
+        self.s3_bucket = self.s3_connection.get_bucket(self.S3_CACHE_BUCKET)
+        # self.versioning = self.s3_bucket.get_versioning_status()
+        # => {} or {'Versioning': 'Enabled'}
 
     def close_spider(self, spider):
         self.s3_connection.close()
@@ -98,7 +119,7 @@ class S3CacheStorage(object):
         """
         key = self._get_key(spider, request)
 
-        epoch = request.meta.get('epoch') # guaranteed to be True or datetime
+        epoch = request.meta.get('epoch')  # guaranteed to be True or datetime
         s3_key = self._get_s3_key(key, epoch)
         logger.debug('S3Storage retrieving response for key %s.' % (s3_key))
 
@@ -116,22 +137,22 @@ class S3CacheStorage(object):
 
         data = json.loads(data_string)
 
-        metadata         = data['metadata']
-        request_headers  = Headers(data['request_headers'])
-        request_body     = data['request_body']
+        metadata = data['metadata']
+        # request_headers = Headers(data['request_headers'])
+        # request_body = data['request_body']
         response_headers = Headers(data['response_headers'])
-        response_body    = data['response_body']
+        response_body = data['response_body']
 
-        if 'binary' in data and data['binary'] == True:
+        if 'binary' in data and data['binary'] is True:
             logger.debug('S3Storage: retrieved binary body')
             response_body = base64.decode(response_body)
 
-        url      = metadata['response_url']
-        status   = metadata.get('status')
+        url = metadata['response_url']
+        status = metadata.get('status')
 
-        logger.debug('S3Storage: response headers {} '.format(response_headers))
+        logger.debug('S3Storage: response headers {}'.format(response_headers))
         Response = responsetypes.from_args(headers=response_headers, url=url, body=response_body)
-        logger.debug('S3Storage: response type {} '.format(Response))
+        logger.debug('S3Storage: response type {}'.format(Response))
 
         return Response(url=url, headers=response_headers, status=status, body=response_body)
 
@@ -141,19 +162,21 @@ class S3CacheStorage(object):
         """
         logger.info('S3Storage: storing response for %s.' % request.url)
         key = self._get_key(spider, request)
-
         logger.info('S3Storage: path %s' % key)
-        logger.debug('S3Storage: response type {} '.format(type(response)))
+        logger.debug('S3Storage: response type {}'.format(type(response)))
+
         if isinstance(response, TextResponse):
-            # Textual response (HTMl, XML, csv, etc.), decoded to unicode using encoding (from Content-Type)
+            # Textual response (HTMl, XML, csv, etc.),
+            # decoded to unicode using encoding (from Content-Type)
             binary = False
             response_body = response.body.decode(response.encoding)
-            logger.debug('S3Storage: encoding {} '.format(response.encoding))
+            logger.debug('S3Storage: encoding {}'.format(response.encoding))
+
         else:
             # Binary response (excel, pdf, etc.)
             binary = True
             response_body = base64.b64encode(response.body)
-            logger.debug('S3Storage: body type {} '.format(type(response_body)))
+            logger.debug('S3Storage: body type {}'.format(type(response_body)))
         logger.debug('S3Storage: request header {}'.format(request.headers))
         logger.debug('S3Storage: response header {}'.format(response.headers))
 
@@ -162,23 +185,22 @@ class S3CacheStorage(object):
             'method': request.method,
             'status': response.status,
             'response_url': response.url,
-            #'timestamp': time(), # This will become the epoch
+            # 'timestamp': time(), # This will become the epoch
         }
 
         data = {
             'binary': binary,
-            'metadata'        : metadata,
-            'request_headers' : request.headers,
-            'request_body'    : request.body,
+            'metadata': metadata,
+            'request_headers': request.headers,
+            'request_body': request.body,
             'response_headers': response.headers,
-            'response_body'   : response_body
+            'response_body': response_body
         }
 
         data_string = json.dumps(data, ensure_ascii=False, encoding='utf-8')
 
-
         # sometimes can cause memory error in SH if too big
-        logger.debug('S3Storage: request/response json object size  {} kB'.format(len(data_string) / 1024))
+        logger.debug('S3Storage: request/response object size {}kB'.format(len(data_string) / 1024))
 
         # With versioning enabled creating a new s3_key is not
         # necessary. We could just write over an old s3_key. However,
@@ -187,24 +209,25 @@ class S3CacheStorage(object):
         s3_key = self.s3_bucket.new_key(key)
 
         try:
-            #s3_key.update_metadata(metadata) #=> can't use this as need to cast to unicode
+            # s3_key.update_metadata(metadata) #=> can't use this as need to cast to unicode
             for k, v in metadata.items():
                 if isinstance(v, str):
                     v = v[:400] + '...' if len(v) > 400 else v
                 s3_key.set_metadata(k, unicode(v))
             s3_key.set_contents_from_string(data_string)
-
-            #save source file
+            # save source file
             if self.SAVE_SOURCE:
-                job_folder = self.SAVE_SOURCE.format(**self._get_uri_params(spider))
+                job_folder = self.SAVE_SOURCE
                 # if the S3 key is too long, the AWS interface does not allow to download the file !
                 source_url = request.url[:200] + '...' if len(request.url) > 200 else request.url
 
-                source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request), urllib.quote_plus(source_url))
+                source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request),
+                                                        urllib.quote_plus(source_url))
                 source_key = self.s3_bucket.new_key(source_name)
                 source_key.set_contents_from_string(response.body)
                 # sometimes can cause memory error in SH if too big
                 logger.debug('S3Storage: body size  {} kB'.format(len(response.body) / 1024))
+
         except boto.exception.S3ResponseError as e:
             # http://docs.pythonboto.org/en/latest/ref/boto.html#module-boto.exception
             #   S3CopyError        : Error copying a key on S3.
@@ -212,16 +235,17 @@ class S3CacheStorage(object):
             #   S3DataError        : Error receiving data from S3.
             #   S3PermissionsError : Permissions error when accessing a bucket or key on S3.
             #   S3ResponseError    : Error in response from S3.
-            #if e.status == 404:   # Not found; probably the wrong bucket name
+            #  if e.status == 404:   # Not found; probably the wrong bucket name
             #    log.msg('S3Storage: %s %s - %s' % (e.status, e.reason, e.body), log.ERROR)
-            #elif e.status == 403: # Forbidden; probably incorrect credentials
+            #  elif e.status == 403: # Forbidden; probably incorrect credentials
             #    log.msg('S3Storage: %s %s - %s' % (e.status, e.reason, e.body), log.ERROR)
             raise e
+
         finally:
             source_key.close()
             s3_key.close()
 
-    #from https://github.com/scrapy/scrapy/blob/342cb622f1ea93268477da557099010bbd72529a/scrapy/extensions/feedexport.py
+    # from https://github.com/scrapy/scrapy/blob/342cb622f1ea93268477da557099010bbd72529a/scrapy/extensions/feedexport.py
     def _get_uri_params(self, spider):
         params = {}
         for k in dir(spider):

--- a/history/storage.py
+++ b/history/storage.py
@@ -159,6 +159,9 @@ class S3CacheStorage(object):
         }
         data_string = json.dumps(data, ensure_ascii=False, encoding='utf-8')
 
+        # sometimes can cause memory error in SH if too big
+        logger.debug('S3Storage: request/response json object size  {} kB'.format(len(data_string) / 1024))
+
         # With versioning enabled creating a new s3_key is not
         # necessary. We could just write over an old s3_key. However,
         # the cost to GET the old s3_key is higher than the cost to
@@ -182,6 +185,8 @@ class S3CacheStorage(object):
                 source_name = "{}/source/{}__{}".format(job_folder, request_fingerprint(request), urllib.quote_plus(source_url))
                 source_key = self.s3_bucket.new_key(source_name)
                 source_key.set_contents_from_string(response.body)
+                # sometimes can cause memory error in SH if too big
+                logger.debug('S3Storage: body size  {} kB'.format(len(response.body) / 1024))
         except boto.exception.S3ResponseError as e:
             # http://docs.pythonboto.org/en/latest/ref/boto.html#module-boto.exception
             #   S3CopyError        : Error copying a key on S3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Project
-scrapy<=0.12.99
+scrapy
 parsedatetime
 boto
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,3 @@
 scrapy
 parsedatetime
 boto
-
-# Testing
-nose
-nose-cov
-coverage

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,17 +1,44 @@
 #!/bin/bash
 
-# Test dacrawl using nose.
-#    --with-doctest              => located and run doctests
-#    --with-cov                  => calculate test coverage
-#    --cov-report=html           => generate html report for test coverage
-#    --cover-erase               => remove old coverage statistics
-#    --cov-config                => use coverage config file
+###
+# Setup virtualenv
+###
 
-# This script will pass any arguments to the end of the nosetests
-# invocation. For example:
-#    (venv)$ ./runtests.sh --pdb-failure # will drop into pdb on failure
+virtualenv --python=python2.7 /home/jenkins/.virtualenvs/jenkins
 
-nosetests \
-    --with-doctest \
-    --with-cov --cov-report=html --cov-config .coveragerc --cover-erase \
-    $@
+wrapper=
+for file in "/usr/share/virtualenvwrapper/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh"
+do
+    echo -n "Does \`${file}' exists ? "
+    [ -f "${file}" ] && { wrapper="$file" ; echo "yes" ; } || { echo "no" ; }
+    [ -n "${wrapper}" ] && break
+done
+[ -z "${wrapper}" ] && { echo "Please install virtualenvwrapper" 1>&2 ; exit 1 ; }
+venv_name="jenkins"
+export WORKON_HOME="/home/jenkins/.virtualenvs"
+source "${wrapper}"
+
+[ -d "$HOME/.virtualenvs/${venv_name}" ] || { mkvirtualenv -a . "${venv_name}" ; }
+workon "${venv_name}" 2> /dev/null
+if [ "0" != "$?" ]
+then
+    echo "Please setup a virtualenv named \`${venv_name}' for this test-runner."
+    exit 1
+fi
+
+set -x
+
+###
+# Intalling/updating dependencies and package
+###
+
+wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+
+pip install --upgrade -r dev-requirements.txt
+pip install -e .
+
+###
+# Environment is set. Start the real work
+###
+
+nosetests -v --stop

--- a/runtests.sh
+++ b/runtests.sh
@@ -11,6 +11,26 @@
 # invocation. For example:
 #    (venv)$ ./runtests.sh --pdb-failure # will drop into pdb on failure
 
+wrapper=
+for file in "/usr/share/virtualenvwrapper/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh"
+do
+    echo -n "Does \`${file}' exists ? "
+    [ -f "${file}" ] && { wrapper="$file" ; echo "yes" ; } || { echo "no" ; }
+    [ -n "${wrapper}" ] && break
+done
+[ -z "${wrapper}" ] && { echo "Please install virtualenvwrapper" 1>&2 ; exit 1 ; }
+
+export WORKON_HOME="/home/teamcity/.virtualenvs"
+source "${wrapper}"
+workon teamcity 2> /dev/null
+if [ "0" != "$?" ]
+then
+    echo "Please setup a virtualenv named \`teamcity' for this test-runner."
+    exit 1
+fi
+
+pip install --upgrade -r requirements.txt
+
 nosetests \
     --with-doctest \
     --with-cov --cov-report=html --cov-config .coveragerc --cover-erase \

--- a/runtests.sh
+++ b/runtests.sh
@@ -11,26 +11,6 @@
 # invocation. For example:
 #    (venv)$ ./runtests.sh --pdb-failure # will drop into pdb on failure
 
-wrapper=
-for file in "/usr/share/virtualenvwrapper/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh"
-do
-    echo -n "Does \`${file}' exists ? "
-    [ -f "${file}" ] && { wrapper="$file" ; echo "yes" ; } || { echo "no" ; }
-    [ -n "${wrapper}" ] && break
-done
-[ -z "${wrapper}" ] && { echo "Please install virtualenvwrapper" 1>&2 ; exit 1 ; }
-
-export WORKON_HOME="/home/teamcity/.virtualenvs"
-source "${wrapper}"
-workon teamcity 2> /dev/null
-if [ "0" != "$?" ]
-then
-    echo "Please setup a virtualenv named \`teamcity' for this test-runner."
-    exit 1
-fi
-
-pip install --upgrade -r requirements.txt
-
 nosetests \
     --with-doctest \
     --with-cov --cov-report=html --cov-config .coveragerc --cover-erase \

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ packages = [
 ]
 
 requires = [
-    'scrapy>=0.12,<=0.12.99',
+    'scrapy',
     'boto',
     'parsedatetime',
 ]

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,16 @@ requires = [
 ]
 
 setup(
-    name='history',
+    name='scrapyhistory',
     version=history.__version__,
     description='Scrapy downloader middleware to enable persistent storage.',
-    long_description=open('README.md').read(),
+    #long_description=open('README.md').read(),
     author='Andrew Preston',
     author_email='andrew@preston.co.nz',
     url='http://github.com/playandbuild/scrapy-history-middleware',
     packages=packages,
     install_requires=requires,
-    license=open('LICENSE').read(),
+    #license=open('LICENSE').read(),
     classifiers=(
         'Development Status :: 4 - Beta'
         'Intended Audience :: Developers',

--- a/teamcity_test.sh
+++ b/teamcity_test.sh
@@ -19,3 +19,5 @@ then
 fi
 
 pip install --upgrade -r requirements.txt
+
+/bin/bash runtests.sh

--- a/teamcity_test.sh
+++ b/teamcity_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+wrapper=
+for file in "/usr/share/virtualenvwrapper/virtualenvwrapper.sh" "/usr/local/bin/virtualenvwrapper.sh"
+do
+    echo -n "Does \`${file}' exists ? "
+    [ -f "${file}" ] && { wrapper="$file" ; echo "yes" ; } || { echo "no" ; }
+    [ -n "${wrapper}" ] && break
+done
+[ -z "${wrapper}" ] && { echo "Please install virtualenvwrapper" 1>&2 ; exit 1 ; }
+
+export WORKON_HOME="/home/teamcity/.virtualenvs"
+source "${wrapper}"
+workon teamcity 2> /dev/null
+if [ "0" != "$?" ]
+then
+    echo "Please setup a virtualenv named \`teamcity' for this test-runner."
+    exit 1
+fi
+
+pip install --upgrade -r requirements.txt

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,27 +1,27 @@
+
 import unittest
 from datetime import datetime
 
-from scrapy.conf import settings
 from scrapy.exceptions import NotConfigured
+from scrapy.utils.test import get_crawler
 
 from history.middleware import HistoryMiddleware
 
-
-settings.overrides['HISTORY'] = {
-    'S3_ACCESS_KEY': '',
-    'S3_SECRET_KEY': '',
-    'S3_BUCKET': '',
-}
+MANDATORY_SETTINGS = ['HISTORY_S3_BUCKET',
+                      'AWS_ACCESS_KEY_ID',
+                      'AWS_SECRET_ACCESS_KEY']
 
 
 class TestHistoryMiddleware(unittest.TestCase):
 
     def setUp(self):
-        self.middleware = HistoryMiddleware()
+        settings_dict = {k: 'mock setting' for k in MANDATORY_SETTINGS}
+        crawler = get_crawler(settings_dict=settings_dict)
+        self.middleware = HistoryMiddleware(crawler)
 
     def test_unconfigured_init(self):
         with self.assertRaises(NotConfigured):
-            self.middleware = HistoryMiddleware(settings={})
+            self.middleware = HistoryMiddleware(get_crawler())
 
     def test_parse_epoch(self):
         self.assertIsInstance(


### PR DESCRIPTION
Make parsing of metadata fields for S3 more robust, as it was failing on some fields that were not unicode.